### PR TITLE
fix icons target dir on Linux

### DIFF
--- a/packages/desktop/Makefile
+++ b/packages/desktop/Makefile
@@ -2,7 +2,7 @@ include $(dir $(lastword $(MAKEFILE_LIST)))../../header.mk
 DESKTOP_SRC := $(d)
 
 ICONS = $(wildcard $(d)*.png) $(wildcard $(d)*.svg)
-ICONS_INSTALLED = $(DESTDIR)$(P_ICON)/hicolor/%/aegisub.
+ICONS_INSTALLED = $(DESTDIR)$(P_ICON)/hicolor/%/apps/aegisub.
 
 DESKTOP_FILE := $(d)aegisub.desktop
 DESKTOP_FILE_PO := $(d)../../po


### PR DESCRIPTION
The /usr/share/icons/hicolor/*x*/ directories contain only subfolders.
