### PR TITLE
fix Linux build

### DIFF
--- a/src/audio_player_portaudio.h
+++ b/src/audio_player_portaudio.h
@@ -95,7 +95,7 @@ class PortAudioPlayer final : public AudioPlayer {
 
 public:
 	/// @brief Constructor
-	PortAudioPlayer(AudioProvider *provider);
+	PortAudioPlayer(agi::AudioProvider *provider);
 
 	/// @brief Destructor
 	~PortAudioPlayer();


### PR DESCRIPTION
Otherwise a build will fail with this message:

```
In file included from /build/buildd/aegisub-unstable-8591/src/preferences.cpp:37:0:
/build/buildd/aegisub-unstable-8591/src/audio_player_portaudio.h:98:32: error: expected ')' before '*' token
  PortAudioPlayer(AudioProvider *provider);
                                ^
cc1plus: warning: unrecognized command line option "-Wno-c++11-narrowing" [enabled by default]
make[1]: *** [/build/buildd/aegisub-unstable-8591/src/preferences.o] Error 1
make[1]: Leaving directory `/build/buildd/aegisub-unstable-8591'
dh_auto_build: make -j1 returned exit code 2
make: *** [build-arch] Error 2
dpkg-buildpackage: error: debian/rules build-arch gave error exit status 2
```
